### PR TITLE
Adding the  following changes:

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 *.retry
 hosts
+vars.*
+*.ini

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,2 @@
 *.retry
 hosts
-vars.*
-*.ini

--- a/example_inventory/vault
+++ b/example_inventory/vault
@@ -1,3 +1,3 @@
-[vaultservers]
+[vault]
 server1.local
 server2.local

--- a/m7-hosts.ini
+++ b/m7-hosts.ini
@@ -1,0 +1,2 @@
+[vault]
+pn2-ifr-lmsm001.ad.issgovernance.com

--- a/plays/roles/vault/defaults/main.yml
+++ b/plays/roles/vault/defaults/main.yml
@@ -1,19 +1,13 @@
 ---
-
 ssl_path: "/etc/vault.d/ssl"
 vault_version: 1.11.3
 domain: localhost.local
 vault_zip_checksum:  sha256:b433413ce524f26abe6292f7fc95f267e809daeacdf7ba92b68dead322f92deb
 vault_cluster_name: "vault-server-{{ inventory_hostname }}"
-
 digital_certs_required: true
-
 zookeeper_endpoint: 
 zookeeper_path:
-
 consul_endpoint: 
 consul_path:
-
 ui_enabled: "true"
-
 vault_bind_interface: 0.0.0.0

--- a/plays/roles/vault/defaults/main.yml
+++ b/plays/roles/vault/defaults/main.yml
@@ -1,5 +1,19 @@
 ---
 
 ssl_path: "/etc/vault.d/ssl"
-vault_version: 1.9.3
+vault_version: 1.11.3
 domain: localhost.local
+vault_zip_checksum:  sha256:b433413ce524f26abe6292f7fc95f267e809daeacdf7ba92b68dead322f92deb
+vault_cluster_name: "vault-server-{{ inventory_hostname }}"
+
+digital_certs_required: true
+
+zookeeper_endpoint: 
+zookeeper_path:
+
+consul_endpoint: 
+consul_path:
+
+ui_enabled: "true"
+
+vault_bind_interface: 0.0.0.0

--- a/plays/roles/vault/tasks/main.yml
+++ b/plays/roles/vault/tasks/main.yml
@@ -12,9 +12,10 @@
 
 
   - name: Copy vault service to server
-    copy:
-      src: vault.service
-      dest: /etc/systemd/system
+    template:
+      src: vault.service.j2
+      dest: /etc/systemd/system/vault.service
+      mode: 0644
 
   - name: create vault group
     group:

--- a/plays/roles/vault/templates/vault.service.j2
+++ b/plays/roles/vault/templates/vault.service.j2
@@ -7,7 +7,11 @@ After=network-online.target
 User=vault
 Group=vault
 PIDFile=/var/run/vault/vault.pid
+{% if digital_certs_required == true %}
 Environment=VAULT_ADDR='https://127.0.0.1:8200'
+{% else %}
+Environment=VAULT_ADDR='http://127.0.0.1:8200'
+{% endif %}
 ExecStart=/usr/local/bin/vault server -config=/etc/vault.d/vault_server.hcl -log-level=debug
 ExecReload=/bin/kill -HUP $MAINPID
 KillMode=process

--- a/plays/roles/vault/templates/vault_server.hcl.j2
+++ b/plays/roles/vault/templates/vault_server.hcl.j2
@@ -3,18 +3,36 @@
 ### vault configuration
 
 listener "tcp" {
-  address          = "{{ ansible_default_ipv4.address }}:8200"
+  address          = "{{ vault_bind_interface }}:8200"
   cluster_address  = "{{ ansible_default_ipv4.address }}:8201"
+{% if digital_certs_required == true %}
   tls_cert_file    = "{{ ssl_path }}/certs/vault-selfsigned.crt"
   tls_key_file     = "{{ ssl_path }}/private/vault-selfsigned.key"
+{% else %}
+  tls_disable = true
+{% endif %}
 }
 
+{% if zookeeper_endpoint|length %}
+storage "zookeeper" {
+  address = "{{ zookeeper_endpoint }}"
+  path    = "{{ zookeeper_path }}"
+}
+{% elif consul_endpoint|length %}
 storage "consul" {
-  address = "127.0.0.1:8500"
-  path    = "vault/"
+  address = "{{ consul_endpoint}}"
+  path    = "{{ consul_path }}"
 }
+{% else %}
+storage "raft" {
+  path = "/opt/vault-storage/raft"
+  node_id = "{{ inventory_hostname }}"
+}
+{% endif %}
 
-ui = true
+ui = {{ ui_enabled }}
 
 api_addr = "http://{{ ansible_default_ipv4.address }}:8200"
 cluster_addr = "https:{{ ansible_default_ipv4.address }}:8201"
+
+cluster_name = "{{ vault_cluster_name }}"

--- a/plays/roles/vault/templates/vault_server.hcl.j2
+++ b/plays/roles/vault/templates/vault_server.hcl.j2
@@ -1,7 +1,6 @@
 # {{ ansible_managed }}
 
 ### vault configuration
-
 listener "tcp" {
   address          = "{{ vault_bind_interface }}:8200"
   cluster_address  = "{{ ansible_default_ipv4.address }}:8201"
@@ -12,7 +11,6 @@ listener "tcp" {
   tls_disable = true
 {% endif %}
 }
-
 {% if zookeeper_endpoint|length %}
 storage "zookeeper" {
   address = "{{ zookeeper_endpoint }}"
@@ -29,10 +27,7 @@ storage "raft" {
   node_id = "{{ inventory_hostname }}"
 }
 {% endif %}
-
 ui = {{ ui_enabled }}
-
 api_addr = "http://{{ ansible_default_ipv4.address }}:8200"
 cluster_addr = "https:{{ ansible_default_ipv4.address }}:8201"
-
 cluster_name = "{{ vault_cluster_name }}"

--- a/plays/server-config.yaml
+++ b/plays/server-config.yaml
@@ -10,6 +10,6 @@
       tags:
         - ssl
         - sslrenew
-    - role: ufw_rules
-      tags:
-        - ufw
+    # - role: ufw_rules
+    #   tags:
+    #     - ufw

--- a/plays/server-config.yaml
+++ b/plays/server-config.yaml
@@ -10,6 +10,6 @@
       tags:
         - ssl
         - sslrenew
-    # - role: ufw_rules
-    #   tags:
-    #     - ufw
+    - role: ufw_rules
+      tags:
+        - ufw

--- a/vars.yaml
+++ b/vars.yaml
@@ -1,0 +1,9 @@
+---
+ssl_path: "/etc/vault.d/ssl"
+vault_version: 1.11.3
+domain: localhost.local
+vault_zip_checksum: sha256:b433413ce524f26abe6292f7fc95f267e809daeacdf7ba92b68dead322f92deb
+zookeeper_endpoint: "pn2-ifr-lmsm001.ad.issgovernance.com:2181,pn2-ifr-lmsm002.ad.issgovernance.com:2181,pn2-ifr-lmsm003.ad.issgovernance.com:2181"
+zookeeper_path: "vault-m7"
+digital_certs_required: true
+ui_enabled: "true"


### PR DESCRIPTION
1. .gitignore contains *.ini and vars.* file, used for customized deployment.
2. Added provision to cusotmize storage backend. Choose from Zookeeper/Consul/Raft.
3. Provide ability to require `digital certs` i.e. TLS based certs.
4. Moved `vault.service` to `templates` to accommodate `digital certs` requirement.
5. `example_inventory` needed HOST names as `vault` instead of `vaultserver`.